### PR TITLE
Add repository for DynamoDBLocal dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,4 +252,11 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <id>dynamodb-local-oregon</id>
+            <name>DynamoDB Local Release Repository</name>
+            <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/release</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Travis seems to use a proxy for maven-central and is not able to resolve `com.amazonaws:DynamoDBLocal:jar`. After local testing with an additional Amazon repository in the main POM it seems to work.