### PR TITLE
Fixed TTL Datatype

### DIFF
--- a/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
@@ -216,7 +216,7 @@ class DefaultDynamoCacheWriter implements DynamoCacheWriter {
     }
 
     if (shouldExpireWithin(ttl)) {
-      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withS(String.valueOf(Instant.now().toEpochMilli() + ttl.toMillis())));
+      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withN(String.valueOf(Instant.now().toEpochMilli() + ttl.toMillis())));
     }
 
     PutItemRequest putItemRequest = new PutItemRequest()


### PR DESCRIPTION
In version 0.9.2 the TTL doesn't work because it is stored as String instead of Number.

See https://aws.amazon.com/de/premiumsupport/knowledge-center/ttl-dynamodb/
