### PR TITLE
Fix unit of TTL in v0.9.3

### DIFF
--- a/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
@@ -216,7 +216,7 @@ class DefaultDynamoCacheWriter implements DynamoCacheWriter {
     }
 
     if (shouldExpireWithin(ttl)) {
-      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withS(String.valueOf(Instant.now().plus(ttl).getEpochSecond())));
+      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withN(String.valueOf(Instant.now().plus(ttl).getEpochSecond())));
     }
 
     PutItemRequest putItemRequest = new PutItemRequest()

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
@@ -216,7 +216,7 @@ class DefaultDynamoCacheWriter implements DynamoCacheWriter {
     }
 
     if (shouldExpireWithin(ttl)) {
-      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withS(String.valueOf(Instant.now().toEpochMilli() + ttl.toMillis())));
+      attributeValues.put(ATTRIBUTE_TTL, new AttributeValue().withS(String.valueOf(Instant.now().plus(ttl).getEpochSecond())));
     }
 
     PutItemRequest putItemRequest = new PutItemRequest()


### PR DESCRIPTION
In version 0.9.3 DynamoDB uses timestamps around the year 51986.

For example
<img width="595" alt="Screenshot 2020-01-07 at 01 20 15" src="https://user-images.githubusercontent.com/8955617/71858573-060aaf00-30ec-11ea-8e11-2bf9ab25ed3f.png">

This is caused by the wrong unit (milliseconds instead of seconds)

Reference to knowledge center: https://aws.amazon.com/de/premiumsupport/knowledge-center/ttl-dynamodb/