### PR TITLE
Additional root attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>aws-java-sdk-dynamodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
@@ -240,9 +240,7 @@ public class DefaultDynamoCacheWriter implements DynamoCacheWriter {
     }
 
     if (rootAttributes != null) {
-      rootAttributes.forEach(rootAttribute -> {
-        attributeValues.put(rootAttribute.getName(), rootAttribute.getAttributeValue());
-      });
+      rootAttributes.forEach(rootAttribute -> attributeValues.put(rootAttribute.getName(), rootAttribute.getAttributeValue()));
     }
 
     PutItemRequest putItemRequest = new PutItemRequest()

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCache.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCache.java
@@ -157,17 +157,26 @@ public class DynamoCache implements Cache {
     return cacheConfig.getTtl();
   }
 
+  /**
+   * Returns the configuration of additional root attributes for this cache
+   *
+   * @return the rootAttributeConfigs value.
+   */
+  public final List<RootAttributeConfig> getRootAttributes() {
+    return cacheConfig.getRootAttributes();
+  }
+
   @Override
   public void put(Object key, Object value) {
     Assert.isTrue(key instanceof String, "'key' must be an instance of 'java.lang.String'.");
-    writer.put(cacheName, (String) key, serialize(value), cacheConfig.getTtl(), readRootAttributes(cacheConfig.getRootAttributeConfigs(), value));
+    writer.put(cacheName, (String) key, serialize(value), cacheConfig.getTtl(), readRootAttributes(cacheConfig.getRootAttributes(), value));
   }
 
   @Override
   public ValueWrapper putIfAbsent(Object key, Object value) {
     Assert.isTrue(key instanceof String, "'key' must be an instance of 'java.lang.String'.");
 
-    byte[] result = writer.putIfAbsent(cacheName, (String) key, serialize(value), cacheConfig.getTtl(), readRootAttributes(cacheConfig.getRootAttributeConfigs(), value));
+    byte[] result = writer.putIfAbsent(cacheName, (String) key, serialize(value), cacheConfig.getTtl(), readRootAttributes(cacheConfig.getRootAttributes(), value));
     if (result != null) {
       LOGGER.debug(String.format("Key: %s already exists in the cache. Element will not be replaced.", key));
       return new SimpleValueWrapper(deserialize(result));

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheBuilder.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheBuilder.java
@@ -16,10 +16,12 @@
 package com.dasburo.spring.cache.dynamo;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttributeConfig;
 import com.dasburo.spring.cache.dynamo.serializer.DynamoSerializer;
 import org.springframework.util.Assert;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * A builder for {@link DynamoCache} instance.
@@ -125,11 +127,23 @@ public class DynamoCacheBuilder {
   }
 
   /**
+   * Give a {@link RootAttributeConfig} to the cache to be built.
+   * Defaults to empty {@link List}.
+   *
+   * @param rootAttributeConfigs additional attributes written into the root level
+   * @return this builder for chaining.
+   */
+  public DynamoCacheBuilder withRootAttributes(List<RootAttributeConfig> rootAttributeConfigs) {
+    this.cacheConfig.setRootAttributeConfigs(rootAttributeConfigs);
+    return this;
+  }
+
+  /**
    * Give a {@link DynamoCacheWriter} to the cache to be built.
    * Defaults to {@link DefaultDynamoCacheWriter}.
    *
    * @param writer a writer doing the actual cache operations.
-   * @return this buzilder for chaining.
+   * @return this builder for chaining.
    */
   public DynamoCacheBuilder withWriter(DynamoCacheWriter writer) {
     this.writer = writer;

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheBuilder.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheBuilder.java
@@ -134,7 +134,7 @@ public class DynamoCacheBuilder {
    * @return this builder for chaining.
    */
   public DynamoCacheBuilder withRootAttributes(List<RootAttributeConfig> rootAttributeConfigs) {
-    this.cacheConfig.setRootAttributeConfigs(rootAttributeConfigs);
+    this.cacheConfig.setRootAttributes(rootAttributeConfigs);
     return this;
   }
 

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheConfiguration.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheConfiguration.java
@@ -14,10 +14,14 @@
  */
 package com.dasburo.spring.cache.dynamo;
 
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttributeConfig;
 import com.dasburo.spring.cache.dynamo.serializer.DynamoSerializer;
 import com.dasburo.spring.cache.dynamo.serializer.StringSerializer;
 
 import java.time.Duration;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 /**
  * A configuration container for a {@link DynamoCache} instance.
@@ -31,17 +35,19 @@ public class DynamoCacheConfiguration {
   private Long readCapacityUnits;
   private Long writeCapacityUnits;
   private DynamoSerializer serializer;
+  private List<RootAttributeConfig> rootAttributeConfigs;
 
-  private DynamoCacheConfiguration(Duration ttl, boolean flushOnBoot, Long readCapacityUnits, Long writeCapacityUnits, DynamoSerializer serializer) {
+  private DynamoCacheConfiguration(Duration ttl, boolean flushOnBoot, Long readCapacityUnits, Long writeCapacityUnits, DynamoSerializer serializer, List<RootAttributeConfig> rootAttributeConfigs) {
     this.ttl = ttl;
     this.flushOnBoot = flushOnBoot;
     this.readCapacityUnits = readCapacityUnits;
     this.writeCapacityUnits = writeCapacityUnits;
     this.serializer = serializer;
+    this.rootAttributeConfigs = rootAttributeConfigs;
   }
 
   public static DynamoCacheConfiguration defaultCacheConfig() {
-    return new DynamoCacheConfiguration(Duration.ZERO, false, 1L, 1L, new StringSerializer());
+    return new DynamoCacheConfiguration(Duration.ZERO, false, 1L, 1L, new StringSerializer(), emptyList());
   }
 
   public Duration getTtl() {
@@ -82,5 +88,13 @@ public class DynamoCacheConfiguration {
 
   public void setSerializer(DynamoSerializer serializer) {
     this.serializer = serializer;
+  }
+
+  public List<RootAttributeConfig> getRootAttributeConfigs() {
+    return rootAttributeConfigs;
+  }
+
+  public void setRootAttributeConfigs(List<RootAttributeConfig> rootAttributeConfigs) {
+    this.rootAttributeConfigs = rootAttributeConfigs;
   }
 }

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheConfiguration.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheConfiguration.java
@@ -35,15 +35,15 @@ public class DynamoCacheConfiguration {
   private Long readCapacityUnits;
   private Long writeCapacityUnits;
   private DynamoSerializer serializer;
-  private List<RootAttributeConfig> rootAttributeConfigs;
+  private List<RootAttributeConfig> rootAttributes;
 
-  private DynamoCacheConfiguration(Duration ttl, boolean flushOnBoot, Long readCapacityUnits, Long writeCapacityUnits, DynamoSerializer serializer, List<RootAttributeConfig> rootAttributeConfigs) {
+  private DynamoCacheConfiguration(Duration ttl, boolean flushOnBoot, Long readCapacityUnits, Long writeCapacityUnits, DynamoSerializer serializer, List<RootAttributeConfig> rootAttributes) {
     this.ttl = ttl;
     this.flushOnBoot = flushOnBoot;
     this.readCapacityUnits = readCapacityUnits;
     this.writeCapacityUnits = writeCapacityUnits;
     this.serializer = serializer;
-    this.rootAttributeConfigs = rootAttributeConfigs;
+    this.rootAttributes = rootAttributes;
   }
 
   public static DynamoCacheConfiguration defaultCacheConfig() {
@@ -90,11 +90,11 @@ public class DynamoCacheConfiguration {
     this.serializer = serializer;
   }
 
-  public List<RootAttributeConfig> getRootAttributeConfigs() {
-    return rootAttributeConfigs;
+  public List<RootAttributeConfig> getRootAttributes() {
+    return rootAttributes;
   }
 
-  public void setRootAttributeConfigs(List<RootAttributeConfig> rootAttributeConfigs) {
-    this.rootAttributeConfigs = rootAttributeConfigs;
+  public void setRootAttributes(List<RootAttributeConfig> rootAttributes) {
+    this.rootAttributes = rootAttributes;
   }
 }

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DynamoCacheWriter.java
@@ -16,10 +16,12 @@
 package com.dasburo.spring.cache.dynamo;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttribute;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * {@link DynamoCacheWriter} provides low level access to DynamoDB commands ({@code PUT, GET, ...}) used for
@@ -79,12 +81,13 @@ public interface DynamoCacheWriter {
    * <br><b>Note:</b> The values size must be less than 400 KB.
    * As this is the maximum element size of a binary in Amazons DynamoDB.
    *
-   * @param name  The cache name must not be {@literal null}.
-   * @param key   The key for the cache entry. Must not be {@literal null}.
-   * @param value The value stored for the key. Must not be {@literal null}.
-   * @param ttl   Optional expiration time. Can be {@literal null}.
+   * @param name           The cache name must not be {@literal null}.
+   * @param key            The key for the cache entry. Must not be {@literal null}.
+   * @param value          The value stored for the key. Must not be {@literal null}.
+   * @param ttl            Optional expiration time. Can be {@literal null}.
+   * @param rootAttributes Optional additional root attributes. Can be {@literal null}.
    */
-  void put(String name, String key, byte[] value, @Nullable Duration ttl);
+  void put(String name, String key, byte[] value, @Nullable Duration ttl, @Nullable List<RootAttribute> rootAttributes);
 
   /**
    * Get the binary value representation from Dynamo stored for the given key.
@@ -101,14 +104,15 @@ public interface DynamoCacheWriter {
    * <br><b>Note:</b> The values size must be less than 400 KB.
    * As this is the maximum element size of a binary in Amazons DynamoDB.
    *
-   * @param name  The cache name must not be {@literal null}.
-   * @param key   The key for the cache entry. Must not be {@literal null}.
-   * @param value The value stored for the key. Must not be {@literal null}.
-   * @param ttl   Optional expiration time. Can be {@literal null}.
+   * @param name           The cache name must not be {@literal null}.
+   * @param key            The key for the cache entry. Must not be {@literal null}.
+   * @param value          The value stored for the key. Must not be {@literal null}.
+   * @param ttl            Optional expiration time. Can be {@literal null}.
+   * @param rootAttributes Optional additional root attributes. Can be {@literal null}.
    * @return {@literal null} if the value has been written, the value stored for the key if it already exists.
    */
   @Nullable
-  byte[] putIfAbsent(String name, String key, byte[] value, @Nullable Duration ttl);
+  byte[] putIfAbsent(String name, String key, byte[] value, @Nullable Duration ttl, @Nullable List<RootAttribute> rootAttributes);
 
   /**
    * Remove the given key from Dynamo.

--- a/src/main/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheAutoConfiguration.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheAutoConfiguration.java
@@ -80,6 +80,7 @@ public class DynamoCacheAutoConfiguration {
             .withReadCapacityUnit(dynamoCacheProperties.getReadCapacityUnits())
             .withWriteCapacityUnit(dynamoCacheProperties.getWriteCapacityUnits())
             .withSerializer(new StringSerializer())
+            .withRootAttributes(dynamoCacheProperties.getRootAttributes())
             .withWriter(DynamoCacheWriter.nonLockingDynamoCacheWriter(dynamoTemplate))
         );
       }

--- a/src/main/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheProperties.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheProperties.java
@@ -15,8 +15,10 @@
 package com.dasburo.spring.cache.dynamo.autoconfigure;
 
 import com.dasburo.spring.cache.dynamo.DynamoCache;
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttributeConfig;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Properties for {@link DynamoCache}.
@@ -28,6 +30,7 @@ public class DynamoCacheProperties {
   private String cacheName;
   private boolean flushOnBoot;
   private Duration ttl;
+  private List<RootAttributeConfig> rootAttributes;
   private Long readCapacityUnits = 1L;
   private Long writeCapacityUnits = 1L;
 
@@ -53,6 +56,14 @@ public class DynamoCacheProperties {
 
   public void setTtl(Duration ttl) {
     this.ttl = ttl;
+  }
+
+  public List<RootAttributeConfig> getRootAttributes() {
+    return rootAttributes;
+  }
+
+  public void setRootAttributes(List<RootAttributeConfig> rootAttributes) {
+    this.rootAttributes = rootAttributes;
   }
 
   public Long getReadCapacityUnits() {

--- a/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttribute.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttribute.java
@@ -1,0 +1,23 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+public class RootAttribute {
+
+  private String name;
+  private AttributeValue value;
+
+  public RootAttribute(String name, AttributeValue value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public AttributeValue getAttributeValue() {
+    return value;
+  }
+
+}

--- a/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfig.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfig.java
@@ -1,0 +1,33 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import org.springframework.util.Assert;
+
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_KEY;
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_TTL;
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_VALUE;
+
+public class RootAttributeConfig {
+
+  private String name;
+  private ScalarAttributeType type;
+
+  public RootAttributeConfig(String name, ScalarAttributeType type) {
+    Assert.notNull(type, "type must not be null!");
+    Assert.notNull(name, "name must not be null!");
+    Assert.isTrue(name.length() > 0, "name must not be empty!");
+    Assert.isTrue(!ATTRIBUTE_KEY.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_KEY+"'");
+    Assert.isTrue(!ATTRIBUTE_VALUE.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_VALUE+"'");
+    Assert.isTrue(!ATTRIBUTE_TTL.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_TTL+"'");
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ScalarAttributeType getType() {
+    return type;
+  }
+}

--- a/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfig.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfig.java
@@ -12,22 +12,34 @@ public class RootAttributeConfig {
   private String name;
   private ScalarAttributeType type;
 
+  /* default constructor required for property binding */
+  public RootAttributeConfig(){
+  }
+
   public RootAttributeConfig(String name, ScalarAttributeType type) {
-    Assert.notNull(type, "type must not be null!");
-    Assert.notNull(name, "name must not be null!");
-    Assert.isTrue(name.length() > 0, "name must not be empty!");
-    Assert.isTrue(!ATTRIBUTE_KEY.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_KEY+"'");
-    Assert.isTrue(!ATTRIBUTE_VALUE.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_VALUE+"'");
-    Assert.isTrue(!ATTRIBUTE_TTL.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_TTL+"'");
-    this.name = name;
-    this.type = type;
+    setName(name);
+    setType(type);
   }
 
   public String getName() {
     return name;
   }
 
+  public void setName(String name) {
+    Assert.notNull(name, "name must not be null!");
+    Assert.isTrue(name.length() > 0, "name must not be empty!");
+    Assert.isTrue(!ATTRIBUTE_KEY.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_KEY+"'");
+    Assert.isTrue(!ATTRIBUTE_VALUE.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_VALUE+"'");
+    Assert.isTrue(!ATTRIBUTE_TTL.equalsIgnoreCase(name), "name must not equal '" + ATTRIBUTE_TTL+"'");
+    this.name = name;
+  }
+
   public ScalarAttributeType getType() {
     return type;
+  }
+
+  public void setType(ScalarAttributeType type) {
+    Assert.notNull(type, "type must not be null!");
+    this.type = type;
   }
 }

--- a/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReader.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReader.java
@@ -19,6 +19,9 @@ public class RootAttributeReader {
   public RootAttribute readRootAttribute(@NonNull RootAttributeConfig rootAttributeConfig, @NonNull Object object) {
     try {
       Object value = PropertyUtils.getProperty(object, rootAttributeConfig.getName());
+      if (value == null) {
+        return null;
+      }
       AttributeValue attributeValue = mapValueToAttributeValue(value, rootAttributeConfig.getType());
       return new RootAttribute(rootAttributeConfig.getName(), attributeValue);
     }
@@ -31,13 +34,13 @@ public class RootAttributeReader {
   @Nullable
   private AttributeValue mapValueToAttributeValue(@NonNull Object value, @NonNull ScalarAttributeType type) {
     switch (type) {
-      case S:
-        return new AttributeValue().withS(String.valueOf(value));
       case N:
         return new AttributeValue().withN(String.valueOf(value));
       case B:
         return new AttributeValue().withB((ByteBuffer) value);
+      case S:
+      default:
+        return new AttributeValue().withS(String.valueOf(value));
     }
-    return null;
   }
 }

--- a/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReader.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReader.java
@@ -1,0 +1,43 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import org.apache.commons.beanutils.PropertyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
+
+public class RootAttributeReader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RootAttributeReader.class);
+
+  @Nullable
+  public RootAttribute readRootAttribute(@NonNull RootAttributeConfig rootAttributeConfig, @NonNull Object object) {
+    try {
+      Object value = PropertyUtils.getProperty(object, rootAttributeConfig.getName());
+      AttributeValue attributeValue = mapValueToAttributeValue(value, rootAttributeConfig.getType());
+      return new RootAttribute(rootAttributeConfig.getName(), attributeValue);
+    }
+    catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      LOGGER.trace("Unable to access attribute {} on instance of class {}", rootAttributeConfig.getName(), object.getClass());
+      return null;
+    }
+  }
+
+  @Nullable
+  private AttributeValue mapValueToAttributeValue(@NonNull Object value, @NonNull ScalarAttributeType type) {
+    switch (type) {
+      case S:
+        return new AttributeValue().withS(String.valueOf(value));
+      case N:
+        return new AttributeValue().withN(String.valueOf(value));
+      case B:
+        return new AttributeValue().withB((ByteBuffer) value);
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/dasburo/spring/cache/dynamo/DynamoCacheTest.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/DynamoCacheTest.java
@@ -15,6 +15,7 @@
 package com.dasburo.spring.cache.dynamo;
 
 import com.dasburo.spring.cache.dynamo.helper.Address;
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttributeConfig;
 import com.dasburo.spring.cache.dynamo.serializer.Jackson2JsonSerializer;
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,7 +29,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.Duration;
 
-import static org.mockito.Mockito.*;
+import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link DynamoCache}.
@@ -292,4 +298,22 @@ public class DynamoCacheTest {
     Assert.assertNotNull(addressCache.get(key));
     Assert.assertEquals(addressCache.get(key).get(), address);
   }
+
+  @Test
+  public void putWithRootAttributeConfigCanBeLoadedAgain() {
+    final String key = "key";
+
+    Address address = new Address("someStreet", 1);
+    DynamoCacheConfiguration config = DynamoCacheConfiguration.defaultCacheConfig();
+    config.setSerializer(new Jackson2JsonSerializer<>(Address.class));
+    config.setRootAttributes(singletonList(new RootAttributeConfig("street", S)));
+
+    Cache addressCache = new DynamoCache(CACHE_NAME, writer, config);
+
+    addressCache.put(key, address);
+
+    Assert.assertNotNull(addressCache.get(key));
+    Assert.assertEquals(addressCache.get(key).get(), address);
+  }
+
 }

--- a/src/test/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheAutoConfigurationTest.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/autoconfigure/DynamoCacheAutoConfigurationTest.java
@@ -14,7 +14,12 @@
  */
 package com.dasburo.spring.cache.dynamo.autoconfigure;
 
-import com.dasburo.spring.cache.dynamo.*;
+import com.dasburo.spring.cache.dynamo.DynamoCache;
+import com.dasburo.spring.cache.dynamo.DynamoCacheManager;
+import com.dasburo.spring.cache.dynamo.TestConfiguration;
+import com.dasburo.spring.cache.dynamo.TestDbCreationRule;
+import com.dasburo.spring.cache.dynamo.UnitTestBase;
+import com.dasburo.spring.cache.dynamo.rootattribute.RootAttributeConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -24,6 +29,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.Duration;
+import java.util.List;
+
+import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
+import static java.util.Arrays.asList;
 
 /**
  * Unit tests for {@code DynamoCacheAutoConfiguration} class.
@@ -39,6 +48,7 @@ public class DynamoCacheAutoConfigurationTest extends UnitTestBase {
   private static final Duration TTL = Duration.ofSeconds(30);
   private static final Long READ_CAPACITY_UNITS = 1L;
   private static final Long WRITE_CAPACITY_UNITS = 1L;
+  private static final List<RootAttributeConfig> ROOT_ATTRIBUTES = asList(new RootAttributeConfig("street", S));
 
   @ClassRule
   public static TestDbCreationRule dynamoDB = new TestDbCreationRule();
@@ -54,7 +64,9 @@ public class DynamoCacheAutoConfigurationTest extends UnitTestBase {
       "spring.cache.dynamo.caches[0].cacheName:" + CACHE_NAME,
       "spring.cache.dynamo.caches[0].flushOnBoot:" + FLUSH_ON_BOOT,
       "spring.cache.dynamo.caches[0].readCapacityUnits:" + READ_CAPACITY_UNITS,
-      "spring.cache.dynamo.caches[0].writeCapacityUnits:" + WRITE_CAPACITY_UNITS
+      "spring.cache.dynamo.caches[0].writeCapacityUnits:" + WRITE_CAPACITY_UNITS,
+      "spring.cache.dynamo.caches[0].rootAttributes[0].name:" + ROOT_ATTRIBUTES.get(0).getName(),
+      "spring.cache.dynamo.caches[0].rootAttributes[0].type:" + ROOT_ATTRIBUTES.get(0).getType().name()
     );
   }
 
@@ -86,6 +98,8 @@ public class DynamoCacheAutoConfigurationTest extends UnitTestBase {
     Assert.assertEquals(TTL, cache.getTtl());
     Assert.assertEquals(CACHE_NAME, cache.getName());
     Assert.assertEquals(FLUSH_ON_BOOT, cache.isFlushOnBoot());
+    Assert.assertEquals(ROOT_ATTRIBUTES.get(0).getName(), cache.getRootAttributes().get(0).getName());
+    Assert.assertEquals(ROOT_ATTRIBUTES.get(0).getType(), cache.getRootAttributes().get(0).getType());
   }
 
 }

--- a/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfigTest.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeConfigTest.java
@@ -1,0 +1,41 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import org.junit.Test;
+
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_KEY;
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_TTL;
+import static com.dasburo.spring.cache.dynamo.DefaultDynamoCacheWriter.ATTRIBUTE_VALUE;
+
+public class RootAttributeConfigTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_TypeMustNotBeNull() {
+    new RootAttributeConfig("sampleField", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_NameMustNotBeNull() {
+    new RootAttributeConfig(null, ScalarAttributeType.S);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_NameMustNotBeEmpty() {
+    new RootAttributeConfig("", ScalarAttributeType.S);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_NameMustNotEqualATTRIBUTE_KEY() {
+    new RootAttributeConfig(ATTRIBUTE_KEY, ScalarAttributeType.S);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_NameMustNotEqualATTRIBUTE_VALUE() {
+    new RootAttributeConfig(ATTRIBUTE_VALUE, ScalarAttributeType.S);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void RootAttributeConfigTest_NameMustNotEqualATTRIBUTE_TTL() {
+    new RootAttributeConfig(ATTRIBUTE_TTL, ScalarAttributeType.S);
+  }
+}

--- a/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReaderTest.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReaderTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class RootAttributeReaderTest {
 
@@ -137,5 +138,32 @@ public class RootAttributeReaderTest {
     //then
     assertEquals("stringField", rootAttribute.getName());
     assertEquals("dummy-text", rootAttribute.getAttributeValue().getS());
+  }
+
+  @Test
+  public void testRootAttributeReader_UnknownFieldIsGetsIgnored() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("unknownField", ScalarAttributeType.S);
+    SampleTestClass sampleInstance = new SampleTestClass();
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertNull(rootAttribute);
+  }
+
+  @Test
+  public void testRootAttributeReader_NullValueOfKnownFieldsGetsIgnored() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("stringField", ScalarAttributeType.S);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setStringField(null);
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertNull(rootAttribute);
   }
 }

--- a/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReaderTest.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/RootAttributeReaderTest.java
@@ -1,0 +1,141 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class RootAttributeReaderTest {
+
+  private RootAttributeReader rootAttributeReader;
+
+  @Before
+  public void setup() {
+    rootAttributeReader = new RootAttributeReader();
+  }
+
+  @Test
+  public void testRootAttributeReader_StringFieldCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("stringField", ScalarAttributeType.S);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setStringField("dummy-value");
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("stringField", rootAttribute.getName());
+    assertEquals("dummy-value", rootAttribute.getAttributeValue().getS());
+  }
+
+  @Test
+  public void testRootAttributeReader_BooleanFieldCanBeHandledAsString() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("booleanField", ScalarAttributeType.S);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setBooleanField(true);
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("booleanField", rootAttribute.getName());
+    assertEquals("true", rootAttribute.getAttributeValue().getS());
+  }
+
+  @Test
+  public void testRootAttributeReader_EnumFieldCanBeHandledAsString() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("enumField", ScalarAttributeType.N);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setEnumField(ScalarAttributeType.S);
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("enumField", rootAttribute.getName());
+    assertEquals("S", rootAttribute.getAttributeValue().getN());
+  }
+
+  @Test
+  public void testRootAttributeReader_IntegerFieldCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("integerField", ScalarAttributeType.N);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setIntegerField(123);
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("integerField", rootAttribute.getName());
+    assertEquals("123", rootAttribute.getAttributeValue().getN());
+  }
+
+  @Test
+  public void testRootAttributeReader_DoubleFieldCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("doubleField", ScalarAttributeType.N);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setDoubleField(123.0);
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("doubleField", rootAttribute.getName());
+    assertEquals("123.0", rootAttribute.getAttributeValue().getN());
+  }
+
+  @Test
+  public void testRootAttributeReader_ByteBufferFieldCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("byteBufferField", ScalarAttributeType.B);
+    SampleTestClass sampleInstance = new SampleTestClass();
+    sampleInstance.setByteBufferField(ByteBuffer.wrap("dummy-text".getBytes()));
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, sampleInstance);
+
+    //then
+    assertEquals("byteBufferField", rootAttribute.getName());
+    assertEquals(ByteBuffer.wrap("dummy-text".getBytes()), rootAttribute.getAttributeValue().getB());
+  }
+
+  @Test
+  public void testRootAttributeReader_HashMapCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("stringField", ScalarAttributeType.S);
+    HashMap<String, String> map = new HashMap<>();
+    map.put("stringField", "dummy-text");
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, map);
+
+    //then
+    assertEquals("stringField", rootAttribute.getName());
+    assertEquals("dummy-text", rootAttribute.getAttributeValue().getS());
+  }
+
+  @Test
+  public void testRootAttributeReader_LinkedHashMapCanBeHandled() {
+    //given
+    RootAttributeConfig rootAttributeConfig = new RootAttributeConfig("stringField", ScalarAttributeType.S);
+    LinkedHashMap<String, String> map = new LinkedHashMap<>();
+    map.put("stringField", "dummy-text");
+
+    //when
+    RootAttribute rootAttribute = rootAttributeReader.readRootAttribute(rootAttributeConfig, map);
+
+    //then
+    assertEquals("stringField", rootAttribute.getName());
+    assertEquals("dummy-text", rootAttribute.getAttributeValue().getS());
+  }
+}

--- a/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/SampleTestClass.java
+++ b/src/test/java/com/dasburo/spring/cache/dynamo/rootattribute/SampleTestClass.java
@@ -1,0 +1,63 @@
+package com.dasburo.spring.cache.dynamo.rootattribute;
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+
+import java.nio.ByteBuffer;
+
+public class SampleTestClass {
+
+  private String stringField;
+  private Boolean booleanField;
+  private ScalarAttributeType enumField;
+  private Integer integerField;
+  private Double doubleField;
+  private ByteBuffer byteBufferField;
+
+  public String getStringField() {
+    return stringField;
+  }
+
+  public void setStringField(String stringField) {
+    this.stringField = stringField;
+  }
+
+  public Boolean getBooleanField() {
+    return booleanField;
+  }
+
+  public void setBooleanField(Boolean booleanField) {
+    this.booleanField = booleanField;
+  }
+
+  public ScalarAttributeType getEnumField() {
+    return enumField;
+  }
+
+  public void setEnumField(ScalarAttributeType enumField) {
+    this.enumField = enumField;
+  }
+
+  public Integer getIntegerField() {
+    return integerField;
+  }
+
+  public void setIntegerField(Integer integerField) {
+    this.integerField = integerField;
+  }
+
+  public Double getDoubleField() {
+    return doubleField;
+  }
+
+  public void setDoubleField(Double doubleField) {
+    this.doubleField = doubleField;
+  }
+
+  public ByteBuffer getByteBufferField() {
+    return byteBufferField;
+  }
+
+  public void setByteBufferField(ByteBuffer byteBufferField) {
+    this.byteBufferField = byteBufferField;
+  }
+}


### PR DESCRIPTION
This PR introduces the possibility to add attributes on root level (beside the core `key` and `value` attributes) as described in https://github.com/bad-opensource/spring-cache-dynamodb/issues/7

The aim of this feature is to improve the cache performance by enabling the usage of Partition Keys on the DynamoDB tables, as well as allowing a fine-grained cache invalidation.

The `RootAttributes` can be configured with the `DynamoCacheBuilder`. For instance
```java
@Bean
public CacheManager cacheManager(AmazonDynamoDB amazonDynamoDB) {
    return new DynamoCacheManager(
        asList(
            DynamoCacheBuilder.newInstance("myCache", amazonDynamoDB)
                .withTTL(Duration.ofSeconds(600))
                .withRootAttributes(asList(new RootAttributeConfig("category", S)))
        )
    );
}
```

or via Properties/Yaml

```yaml
spring:
  cache:
    dynamo:
      caches:
        - cacheName: myCache
          ttl: 600s
          rootAttributes:
            - name: category
              type: S
```

I made the `DefaultDynamoCacheWriter` class and its `ATTRIBUTE_*` fields public to reuse them.