### PR TITLE
DynamoDB::CreateTable permission should be unnecessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.5] - 2020-03-12
+### Changed 
+- the `DynamoDB::CreateTable` permission is not required anymore if the table already exist [@derXear](https://github.com/derXear)
+
 ## [0.9.4] - 2020-01-14
 ### Fixed 
 - fix unit used for ttl from EpochMillis to EpochSeconds [@dnltsk](https://github.com/dnltsk)
@@ -26,7 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - initial code base by [@derXear](https://github.com/derXear)
 
-[Unreleased]: https://github.com/bad-opensource/spring-cache-dynamodb/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/bad-opensource/spring-cache-dynamodb/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/bad-opensource/spring-cache-dynamodb/releases/tag/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/bad-opensource/spring-cache-dynamodb/releases/tag/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/bad-opensource/spring-cache-dynamodb/releases/tag/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/bad-opensource/spring-cache-dynamodb/releases/tag/v0.9.1...v0.9.2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To integrate this Git repository into your project, simply add the maven depende
 <dependency>
     <groupId>com.dasburo</groupId>
     <artifactId>spring-cache-dynamodb</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.dasburo</groupId>
     <artifactId>spring-cache-dynamodb</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
 
     <name>Amazon DynamoDB for Spring Cache</name>
     <description>Spring Cache implementation based on Amazon DynamoDB</description>

--- a/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
+++ b/src/main/java/com/dasburo/spring/cache/dynamo/DefaultDynamoCacheWriter.java
@@ -169,9 +169,14 @@ class DefaultDynamoCacheWriter implements DynamoCacheWriter {
     Assert.notNull(name, "Name must not be null!");
     Assert.notNull(ttl, "TTL must not be null! Use Duration.ZERO to disable TTL.");
 
-    boolean created = TableUtils.createTableIfNotExists(dynamoTemplate, createTableRequest(name, readCapacityUnits, writeCapacityUnits));
-    if (created && !ttl.isZero()) {
-      dynamoTemplate.updateTimeToLive(updateTimeToLiveRequest(name));
+    boolean created = false;
+    try {
+      dynamoTemplate.describeTable(name);
+    } catch(ResourceNotFoundException e) {
+      created = TableUtils.createTableIfNotExists(dynamoTemplate, createTableRequest(name, readCapacityUnits, writeCapacityUnits));
+      if (created && !ttl.isZero()) {
+        dynamoTemplate.updateTimeToLive(updateTimeToLiveRequest(name));
+      }
     }
     return created;
   }


### PR DESCRIPTION
The `CreateTable` permission should not be required to use the library if the table already exist.